### PR TITLE
running app is now depended on all tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,3 +58,7 @@ dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-contrib:2.0'
 
 }
+
+afterEvaluate {
+    assembleDebug.dependsOn check
+}


### PR DESCRIPTION
In this PR I added a build dependency on the check task. The check task is responsible for running all tests. 
So now then you run your app for checking a new feature you will now you haven't messed another flow (that has a test).